### PR TITLE
Remove defined policy from DyanmoDB and S3 endpoints as matched default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,19 +6,6 @@ resource "aws_vpc_endpoint" "s3_endpoint" {
   vpc_endpoint_type = "Gateway"
   service_name      = "com.amazonaws.${data.aws_region.current_region.name}.s3"
   route_table_ids   = ["${var.route_tables_ids_list}"]
-
-  policy = <<POLICY
-{
-    "Statement": [
-        {
-            "Action": "s3:*",
-            "Effect": "Allow",
-            "Resource": "*",
-            "Principal": "*"
-        }
-    ]
-}
-POLICY
 }
 
 resource "aws_vpc_endpoint" "dynamo_endpoint" {
@@ -27,19 +14,6 @@ resource "aws_vpc_endpoint" "dynamo_endpoint" {
   vpc_endpoint_type = "Gateway"
   service_name      = "com.amazonaws.${data.aws_region.current_region.name}.dynamodb"
   route_table_ids   = ["${var.route_tables_ids_list}"]
-
-  policy = <<POLICY
-{
-    "Statement": [
-        {
-            "Action": "dynamodb:*",
-            "Effect": "Allow",
-            "Resource": "*",
-            "Principal": "*"
-        }
-    ]
-}
-POLICY
 }
 
 # codebuild


### PR DESCRIPTION
DynamoDB and S3 endpoint creation had a static policy defined that matched the default. This meant that subsequent plans would want to set the policy explicitly, giving the below output:

```
    ~ module.vpc_endpoint.aws_vpc_endpoint.dynamo_endpoint
    policy:                                  
        "{
          \"Statement\":[
            {\
              "Action\":\"dynamodb:*\",\
              "Effect\":\"Allow\",\
              "Principal\":\"*\",\
              "Resource\":\"*\"
            }
          ],\
          "Version\":\"2008-10-17\"
        }" 
        => 
        "{\"
          Statement\":
            [
              {\"Action\":\"dynamodb:*\",\
              "Effect\":\"Allow\",\
              "Principal\":\"*\",\
              "Resource\":\"*\"
            }
          ]
        }"

    ~ module.vpc_endpoint.aws_vpc_endpoint.s3_endpoint
    policy:                                  
        "{\
          "Statement\":[
            {\
              "Action\":\"s3:*\",\
              "Effect\":\"Allow\",\
              "Principal\":\"*\",\
              "Resource\":\"*\"
            }
          ],\
          "Version\":\"2008-10-17\"
        }" 
        => 
        "{\
          "Statement\":
            [
              {\
                "Action\":\"s3:*\",\
                "Effect\":\"Allow\",\
                "Principal\":\"*\",\
                "Resource\":\"*\"
              }
            ]
          }"
```
This was unnecessary. Resolution was to remove the explicit policy and let the default do its work.