### PR TITLE
Update module pinnings to latest version

### DIFF
--- a/examples/advanced.tf
+++ b/examples/advanced.tf
@@ -4,18 +4,18 @@ provider "aws" {
 }
 
 module "base_network" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.1"
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.6"
   vpc_name = "VPC-Endpoint-Test"
 }
 
 module "security_groups" {
-  source        = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.3"
+  source        = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.5"
   resource_name = "test_sg"
   vpc_id        = "${module.base_network.vpc_id}"
 }
 
 module "vpc_endpoint" {
-  source                                  = "../../module"
+  source                                  = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.3"
   resource_name                           = "VPC-Endpoint-Testing"
   vpc_id                                  = "${module.base_network.vpc_id}"
   route_tables_ids_list                   = "${module.base_network.private_route_tables}"

--- a/examples/basic.tf
+++ b/examples/basic.tf
@@ -4,12 +4,12 @@ provider "aws" {
 }
 
 module "base_network" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.1"
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.6"
   vpc_name = "VPC-Endpoint-Exammple"
 }
 
 module "vpc_endpoint" {
-  source                    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.1"
+  source                    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.3"
   resource_name             = "VPC-Endpoint-Exammple"
   vpc_id                    = "${module.base_network.vpc_id}"
   route_tables_ids_list     = "${module.base_network.private_route_tables}"

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "base_network" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.1"
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
   vpc_name = "VPC-Endpoint-Test"
 }
 


### PR DESCRIPTION
Update module examples to latest versions
Update tests to use master branch. - Update the pinning of the security group module was left unchanged due to the change causing replacement of the security groups.  As the security groups were in use, this deletion attempt timed out.