### PR TITLE
Remove resource_name as it's not used in endpoints, update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # aws-terraform-vpc_endpoint
 
+This module builds VPC endpoints based on the inputs.
+
+## Basic Usage
+
+```
+module "vpc_endpoint" {
+  source                    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.4"
+  vpc_id                    = "${module.base_network.vpc_id}"
+  route_tables_ids_list     = "${module.base_network.private_route_tables}"
+  dynamo_db_endpoint_enable = true
+  s3_endpoint_enable        = true
+}
+```
+
+Full working references are available at [examples](examples)
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -66,3 +82,4 @@
 | servicecatalog\_vpc\_endpoint\_id | Servicecatalog vpc endpoint ID |
 | sns\_vpc\_endpoint\_id | SNS vpc endpoint ID |
 | ssm\_vpc\_endpoint\_id | SSM vpc endpoint ID |
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# aws-terraform-vpc_endpoint
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -26,7 +28,6 @@
 | logs\_private\_dns\_enable | Enable/Disable private dns on the logs endpoint. Allowed values: true, false | string | `"false"` | no |
 | monitoring\_endpoint\_enable | Enable/Disable the monitoring VPC Endpoint. Allowed values: true, false | string | `"false"` | no |
 | monitoring\_private\_dns\_enable | Enable/Disable private dns on the monitoring endpoint. Allowed values: true, false | string | `"false"` | no |
-| resource\_name | The name to be used for resources provisioned by this module | string | n/a | yes |
 | route\_tables\_ids\_list | List of Route Table ID's for each AZ | list | `<list>` | no |
 | s3\_endpoint\_enable | Enable/Disable the S3 VPC Endpoint. Allowed values: true, false | string | `"true"` | no |
 | sagemaker\_runtime\_endpoint\_enable | Enable/Disable the sagemaker.runtime VPC Endpoint. Allowed values: true, false | string | `"false"` | no |
@@ -65,4 +66,3 @@
 | servicecatalog\_vpc\_endpoint\_id | Servicecatalog vpc endpoint ID |
 | sns\_vpc\_endpoint\_id | SNS vpc endpoint ID |
 | ssm\_vpc\_endpoint\_id | SSM vpc endpoint ID |
-

--- a/examples/advanced.tf
+++ b/examples/advanced.tf
@@ -15,8 +15,7 @@ module "security_groups" {
 }
 
 module "vpc_endpoint" {
-  source                                  = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.3"
-  resource_name                           = "VPC-Endpoint-Testing"
+  source                                  = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.4"
   vpc_id                                  = "${module.base_network.vpc_id}"
   route_tables_ids_list                   = "${module.base_network.private_route_tables}"
   security_group_ids_list                 = ["${module.security_groups.vpc_endpoint_security_group_id}"]

--- a/examples/basic.tf
+++ b/examples/basic.tf
@@ -9,8 +9,7 @@ module "base_network" {
 }
 
 module "vpc_endpoint" {
-  source                    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.3"
-  resource_name             = "VPC-Endpoint-Exammple"
+  source                    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.4"
   vpc_id                    = "${module.base_network.vpc_id}"
   route_tables_ids_list     = "${module.base_network.private_route_tables}"
   dynamo_db_endpoint_enable = true

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,23 @@
+/**
+ * # aws-terraform-vpc_endpoint
+ *
+ *This module builds VPC endpoints based on the inputs.
+ *
+ *## Basic Usage
+ *
+ *```
+ * module "vpc_endpoint" {
+ *   source                    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_endpoint?ref=v0.0.4"
+ *   vpc_id                    = "${module.base_network.vpc_id}"
+ *   route_tables_ids_list     = "${module.base_network.private_route_tables}"
+ *   dynamo_db_endpoint_enable = true
+ *   s3_endpoint_enable        = true
+ * }
+ *```
+ *
+ * Full working references are available at [examples](examples)
+ */
+
 data "aws_region" "current_region" {}
 
 resource "aws_vpc_endpoint" "s3_endpoint" {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -16,7 +16,6 @@ module "security_groups" {
 
 module "vpc_endpoint" {
   source                                  = "../../module"
-  resource_name                           = "VPC-Endpoint-Testing"
   vpc_id                                  = "${module.base_network.vpc_id}"
   route_tables_ids_list                   = "${module.base_network.private_route_tables}"
   security_group_ids_list                 = ["${module.security_groups.vpc_endpoint_security_group_id}"]

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "resource_name" {
-  description = "The name to be used for resources provisioned by this module"
-  type        = "string"
-}
-
 variable "environment" {
   description = "Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test')"
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):

https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/204

##### Summary of change(s):

Remove `resource_name` variable and removed it from tests and examples

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes

##### Do examples need to be updated based on changes?

Yes and done

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.